### PR TITLE
access to non-object property fix

### DIFF
--- a/backoffice/modules/mod-8-categories/actions/add.php
+++ b/backoffice/modules/mod-8-categories/actions/add.php
@@ -151,7 +151,7 @@ if (!isset($_POST["save"])) {
 
 		if(!empty($_POST["files-fallback"])) {
 			$file = new file();
-			$file->fallback($obj->id, $_POST["files-fallback"]);
+			$file->fallback($obj["id"], $_POST["files-fallback"]);
 		}
 	} else {
 		$textToPrint = $mdl_lang["add"]["failure"];


### PR DESCRIPTION
the function "returnObject", defined on class.8-category.php, returns an array and not an object.